### PR TITLE
[IDP-976] Disabled CA1860, fixed IDE0058 and changed globalization/culture rule severity from suggestion to silent

### DIFF
--- a/src/files/2_CodeStyle.editorconfig
+++ b/src/files/2_CodeStyle.editorconfig
@@ -120,7 +120,7 @@ csharp_style_prefer_tuple_swap = true
 csharp_style_prefer_utf8_string_literals = true
 csharp_style_throw_expression = true
 csharp_style_unused_value_assignment_preference = discard_variable
-csharp_style_unused_value_expression_statement_preference = discard_variable:warning
+csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
 csharp_using_directive_placement = outside_namespace:warning

--- a/src/files/3_AllProjectsAnalyzers.editorconfig
+++ b/src/files/3_AllProjectsAnalyzers.editorconfig
@@ -393,13 +393,13 @@ dotnet_diagnostic.CA1200.severity = none
 # CA1310: Specify StringComparison for correctness (ex: string.Compare)
 # CA1311: Specify a culture or use an invariant version (ex: string.ToUpper)
 dotnet_diagnostic.CA1303.severity = none
-dotnet_diagnostic.CA1304.severity = suggestion
-dotnet_diagnostic.CA1305.severity = suggestion
-dotnet_diagnostic.CA1307.severity = suggestion
+dotnet_diagnostic.CA1304.severity = silent
+dotnet_diagnostic.CA1305.severity = silent
+dotnet_diagnostic.CA1307.severity = silent
 dotnet_diagnostic.CA1308.severity = none
-dotnet_diagnostic.CA1309.severity = suggestion
-dotnet_diagnostic.CA1310.severity = suggestion
-dotnet_diagnostic.CA1311.severity = suggestion
+dotnet_diagnostic.CA1309.severity = silent
+dotnet_diagnostic.CA1310.severity = silent
+dotnet_diagnostic.CA1311.severity = silent
 
 # CA1507: Use nameof in place of string
 # Disabled because it was suggested when using [Newtonsoft.Json.JsonProperty],
@@ -456,6 +456,11 @@ dotnet_diagnostic.CA1848.severity = none
 # CA1859: Use concrete types when possible for improved performance
 # Disabled, down-casting doesn't degrade performance that much
 dotnet_diagnostic.CA1859.severity = none
+
+# CA1860: Avoid using 'Enumerable.Any()' extension method (instead of Length, Count or IsEmpty)
+# Disabled because the modern version of 'Any()'' has been significantly optimized for types that implement IReadOnlyCollection
+# 'Any' may also be considered more readable in some cases
+dotnet_diagnostic.CA1860.severity = none
 
 # CA1863: Use 'CompositeFormat'
 # Disabled, this is fairly new and the performance gains over string.Format isn't worth it


### PR DESCRIPTION
- Disabled CA1860
- Fixed IDE0058 (was disabled, but its option was configured as a warning = conflict)
- Changed globalization/culture rule severity from suggestion to silent
