### PR TITLE
[IDP-1146] Add timestamp to version for nuget publish step

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -25,7 +25,8 @@ Process {
     Exec { & dotnet tool restore }
 
     # Let GitVersion compute the NuGet package version
-    $version = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
+    $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
+    $version = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer } + ".$uniqueId"
 
     # Pack using NuGet.exe
     Exec { & nuget pack Workleap.DotNet.CodingStandards.nuspec -OutputDirectory $outputDir -Version $version -ForceEnglishOutput }
@@ -35,7 +36,7 @@ Process {
 
     # Push to a NuGet feed if the environment variables are set
     if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-      Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
+      Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
     }
   }
   finally {

--- a/Build.ps1
+++ b/Build.ps1
@@ -26,7 +26,8 @@ Process {
 
     # Let GitVersion compute the NuGet package version
     $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
-    $version = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer } + ".$uniqueId"
+    $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
+    $version = "$gitVersion.$uniqueId"
 
     # Pack using NuGet.exe
     Exec { & nuget pack Workleap.DotNet.CodingStandards.nuspec -OutputDirectory $outputDir -Version $version -ForceEnglishOutput }

--- a/Build.ps1
+++ b/Build.ps1
@@ -35,7 +35,7 @@ Process {
 
     # Push to a NuGet feed if the environment variables are set
     if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-      Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
+      Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
     }
   }
   finally {

--- a/Build.ps1
+++ b/Build.ps1
@@ -25,9 +25,9 @@ Process {
     Exec { & dotnet tool restore }
 
     # Let GitVersion compute the NuGet package version
-    $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
+    $shortSHA = Exec { & git rev-parse --short HEAD }
     $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
-    $version = "$gitVersion.$uniqueId"
+    $version = "$gitVersion.$shortSHA"
 
     # Pack using NuGet.exe
     Exec { & nuget pack Workleap.DotNet.CodingStandards.nuspec -OutputDirectory $outputDir -Version $version -ForceEnglishOutput }


### PR DESCRIPTION
## Description of changes
To ensure we are publishing a new version with each PR, we can add a timestamp ID to the version value.

## Breaking changes
None

## Additional checks

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
