### PR TITLE
Add MSBuildTreatWarningsAsErrors alongside TreatWarningsAsErrors

### DIFF
--- a/src/build/Workleap.DotNet.CodingStandards.props
+++ b/src/build/Workleap.DotNet.CodingStandards.props
@@ -17,8 +17,9 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ContinuousIntegrationBuild Condition="'$(TEAMCITY_VERSION)' != ''">true</ContinuousIntegrationBuild>
 
-    <!-- TreatWarningsAsErrors is enabled for release builds, unless explicitly set -->
+    <!-- TreatWarningsAsErrors and MSBuildTreatWarningsAsErrors are enabled for release builds, unless explicitly set -->
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release' AND '$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release' AND '$(MSBuildTreatWarningsAsErrors)' == ''">true</MSBuildTreatWarningsAsErrors>
 
     <!-- https://devblogs.microsoft.com/visualstudio/vs-toolbox-accelerate-your-builds-of-sdk-style-net-projects/ -->
     <AccelerateBuildsInVisualStudio Condition="'$(AccelerateBuildsInVisualStudio)' == ''">true</AccelerateBuildsInVisualStudio>

--- a/tests/Workleap.DotNet.CodingStandards.Tests/CodingStandardTests.cs
+++ b/tests/Workleap.DotNet.CodingStandards.Tests/CodingStandardTests.cs
@@ -26,6 +26,42 @@ public sealed class CodingStandardTests(PackageFixture fixture, ITestOutputHelpe
     }
 
     [Fact]
+    public async Task MSBuildWarningsAsErrorOnDebugConfiguration()
+    {
+        using var project = new ProjectBuilder(fixture, testOutputHelper);
+        project.AddCsprojFile(packageReferences: new Dictionary<string, string> { { "Azure.Identity", "1.10.4" } });
+        project.AddFile("sample.cs", """
+             namespace sample;
+             public static class Sample
+             {
+                 public static void Main(string[] args)
+                 {
+                 }
+             }
+             """);
+        var data = await project.BuildAndGetOutput();
+        Assert.True(data.HasWarning("NU1902"));
+    }
+
+    [Fact]
+    public async Task MSBuildWarningsAsErrorOnReleaseConfiguration()
+    {
+        using var project = new ProjectBuilder(fixture, testOutputHelper);
+        project.AddCsprojFile(packageReferences: new Dictionary<string, string> { { "Azure.Identity", "1.10.4" } });
+        project.AddFile("sample.cs", """
+             namespace sample;
+             public static class Sample
+             {
+                 public static void Main(string[] args)
+                 {
+                 }
+             }
+             """);
+        var data = await project.BuildAndGetOutput(["--configuration", "Release"]);
+        Assert.True(data.HasError("NU1902"));
+    }
+
+    [Fact]
     public async Task NamingConvention_Invalid()
     {
         using var project = new ProjectBuilder(fixture, testOutputHelper);


### PR DESCRIPTION
## Description of changes
Added MSBuildTreatWarningsAsErrors property alongside the TreatWarningsAsErrors one.

This allows builds that do not specify the /warnaserror flag to still promote nuget dependency vulnerability warnings into errors by default, similar to how TreatWarningsAsErrors works for common warnings.

## Breaking changes
If this end up breaking a build, it means there were warnings being ignored. Either manually specify the desired value for MSBuildTreatWarningsAsErrors in the project to override the default, or fix the warnings themselves.

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
