### PR TITLE
Ban InvariantCulture/InvariantCultureIgnoreCase

### DIFF
--- a/src/files/BannedSymbols.txt
+++ b/src/files/BannedSymbols.txt
@@ -1,3 +1,8 @@
 P:System.DateTime.Now;Use System.DateTime.UtcNow instead.
 P:System.DateTimeOffset.Now;Use System.DateTimeOffset.UtcNow instead.
 P:System.DateTimeOffset.DateTime;Use System.DateTimeOffset.UtcDateTime instead.
+
+F:System.StringComparison.InvariantCulture;InvariantCulture performs a linguistic comparison. Most of the time Ordinal is the correct one.
+F:System.StringComparison.InvariantCultureIgnoreCase;InvariantCultureIgnoreCase performs a linguistic comparison. Most of the time OrdinalIgnoreCase is the correct one.
+P:System.StringComparer.InvariantCulture;InvariantCulture performs a linguistic comparison. Most of the time Ordinal is the correct one.
+P:System.StringComparer.InvariantCultureIgnoreCase;InvariantCultureIgnoreCase performs a linguistic comparison. Most of the time OrdinalIgnoreCase is the correct one.


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

These symbols are almost never ok, so we should ban them and suggest using `Ordinal` or `OrdinalIgnoreCase`. Using `InvariantCulture` to compare 2 strings is not invariant as it uses a linguistical rules instead of comparing bytes. So, it can lead to unexpected results. Also, it’s much slower.

````
// true, but I don't know this is what developers expect
string.Equals("a\0bc", "abc", StringComparison.InvariantCulture)
string.Equals("A꙰B", "AB", StringComparison.InvariantCultureIgnoreCase)

// true using NLS, false using ICU
string.Equals("ss", "ß", StringComparison.InvariantCultureIgnoreCase)
````

## Breaking changes

It may break build on projects using any of these symbols.

- Replace InvariantCulture with Ordinal
- Replace InvariantCultureIgnoreCase with OrdinalIgnoreCase
- Use `#pragma warning disable` or `SuppressMessageAttribute`

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
