### PR TITLE
Add new lines before members in object initializers

### DIFF
--- a/src/files/3_ReSharperAnalyzers.editorconfig
+++ b/src/files/3_ReSharperAnalyzers.editorconfig
@@ -8,3 +8,7 @@ resharper_check_namespace_highlighting = none
 
 # Already covered by file defaults "insert_final_newline"
 csharp_insert_final_newline = false
+
+# Fix to address https://youtrack.jetbrains.com/issue/RSRP-486359
+# where csharp_new_line_before_members_in_object_initializers would still inline object initializers
+resharper_wrap_object_and_collection_initializer_style = chop_always


### PR DESCRIPTION
## Description of changes

Insert new lines between members in object initializers with Rider (or R#). The default .NET styling option doesn't work.

When using our .NET Coding standards, reformating in Rider these pieces of code:

```csharp
var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
{
    EnvironmentName = Environments.Production,
});

// ...

await notificationService.PublishUpdateAsync(proxyResource, state => state with
{
    State = KnownResourceStates.Running,
    Urls = [new UrlSnapshot(Name: "http", Url: "http://127.0.0.1:1234", IsInternal: false)],
});
```

… will automatically inline the object initializer to:

```csharp
var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production, });

// ...

await notificationService.PublishUpdateAsync(proxyResource, state => state with { State = KnownResourceStates.Running, Urls = [new UrlSnapshot(Name: "http", Url: "http://127.0.0.1:1234", IsInternal: false)], });
```

This would affect code that developers haven’t edited, resulting in unwanted changes that make code less readable and require reviewers to ask the PR author to revert the code to its original state.

This happens sometimes automatically as some IDEs are configured to reformat new changes automatically.

I've seen PRs of developers using our coding standards where they would complain about it (but still commit the inlined code anyway).

## Breaking changes

There's no warning or errors involved here, it's mostly styling.
