### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-dotnet-codingstandards
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request introduces a small update to the `.github/workflows/publish.yml` file. The change adds a `cortexEntityIdOrTag` parameter to the workflow configuration to specify the service entity for deployment.